### PR TITLE
Hook für lokale Firewallregeln auf dem Server hinzugefügt

### DIFF
--- a/etc/init.d/linuxmuster-base
+++ b/etc/init.d/linuxmuster-base
@@ -125,6 +125,10 @@ start_firewall() {
       done <$BLOCKEDPORTS
     fi
 
+    if [ -r /etc/linuxmuster/local-fwrules ]; then
+	. /etc/linuxmuster/local-fwrules
+    fi
+
     # don't do this when reloading
     if [ -z "$reload" ]; then
 


### PR DESCRIPTION
Hallo, ich habe nach einer Stelle gesucht, wo ich per lokalen Firewall-Regeln bestimmte Ports nur von einem Host aus erlauben kann. Da ich nichts gefunden habe und ungern in Dateien editiere, die bei Updates sehr wahrscheinlich ersetzt werden, habe ich lokal den "hook" eingebaut - toll wäre, wenn sowas in der Art upstream integriert werden könnte ;-)
