### PR TITLE
Unterstützung für linuxmuster-moodle und einen Dyndns-Namen

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linuxmuster-base (6.0.25-0ubuntu0-1moodle) precise; urgency=low
+
+  * added moodle patch
+
+ -- Frank Schütte <fschuett@gymnasium-himmelsthuer.de>  Sat, 26 Jan 2013 18:04:42 +0100
+
 linuxmuster-base (6.0.25-0ubuntu0) precise; urgency=low
 
   * internal firewall init script:

--- a/debian/postinst
+++ b/debian/postinst
@@ -28,7 +28,8 @@ read_values(){
  echo "Reading values from debconf ..."
 
  for i in country state location schoolname servername domainname workgroup fwconfig \
-          smtprelay sambasid internmask internmask_short internsubrange iface_lan; do
+          smtprelay sambasid internmask internmask_short internsubrange iface_lan \
+          serverexternname; do
   eval $i="$(echo "get linuxmuster-base/$i" | debconf-communicate | awk '{ print $2 }')"
  done
  

--- a/debian/templates
+++ b/debian/templates
@@ -167,3 +167,12 @@ Default: eth0
 Description: lan interface
  Keine Eingabe.
 
+Template: linuxmuster-base/serverexternname
+Type: string
+Default: server.linuxmuster-net.lokal
+Description: Externer Name des Servers?
+ Geben Sie hier z.B. eine existierende Dyndns-Adresse\n
+ des Servers ein. Falls der Server nicht vom Internet aus\n
+ erreichbar sein soll bzw. die interne und externe \n
+ Addresse übereinstimmen, kann das Feld auch leer\n
+ bleiben.

--- a/sbin/linuxmuster-setup
+++ b/sbin/linuxmuster-setup
@@ -124,7 +124,8 @@ case $opt in
     echo "Reading current configuration values ..." | tee -a $logfile
     rm -f $OLDVALUES
     for i in country state location workgroup servername domainname \
-             schoolname smtprelay internsubrange fwconfig; do
+             schoolname smtprelay internsubrange fwconfig \
+             serverexternname; do
      RET="$(echo get linuxmuster-base/$i | debconf-communicate | awk '{ print $2 }')"
      oldvalue="${i}_old"
      echo "$oldvalue=\"$RET\"" >> $OLDVALUES

--- a/share/scripts/linuxmuster-config
+++ b/share/scripts/linuxmuster-config
@@ -115,6 +115,16 @@ while ! validdomain "$SMTPRELAY"; do
 done
 
 
+# extern server name
+while ! validdomain "$SERVEREXTERNNAME"; do
+	db_fset linuxmuster-base/serverexternname seen false
+	db_input $PRIORITY linuxmuster-base/serverexternname || true
+	db_go
+	db_get linuxmuster-base/serverexternname || true
+	SERVEREXTERNNAME=$RET
+	if [ "$SERVEREXTERNNAME" = "" ]; then break; fi
+done
+
 # admin passwords
 if [ "$1" = "--first" ]; then
 

--- a/share/scripts/linuxmuster-patch
+++ b/share/scripts/linuxmuster-patch
@@ -17,7 +17,7 @@ echo "Reading debconf database ..."
 for i in country state location servername domainname schoolname \
          internmask internmask_short internsubrange fwconfig \
          smtprelay sambasid adminpw pgmadminpw wwwadminpw \
-         ipcoppw workgroup iface_lan; do
+         ipcoppw workgroup iface_lan serverexternname; do
   eval $i="$(echo get linuxmuster-base/$i | debconf-communicate | awk '{ print $2 }')"
 done
 
@@ -247,7 +247,8 @@ for i in $DYNTPLDIR/*; do
               s/@@printeradmins@@/${PRINTERADMINS}/g
               s/@@admingroup@@/${ADMINGROUP}/g
               s/@@teachersgroup@@/${TEACHERSGROUP}/g
-              s/@@wwwadmin@@/${WWWADMIN}/g" $conffile > $target
+              s/@@wwwadmin@@/${WWWADMIN}/g
+              s/@@serverexternname@@/${serverexternname}/g" $conffile > $target
     done
   fi
   # do something after the configuration is patched

--- a/var/config-dynamic/04_bind9/db.extern
+++ b/var/config-dynamic/04_bind9/db.extern
@@ -1,0 +1,15 @@
+;
+; BIND data file for @@serverexternname@@
+;
+$TTL	3600
+@	IN	SOA	@@serverexternname@@. root.@@serverexternname@@. (
+			      1		; Serial
+			  10800		; Refresh
+			   3600		; Retry
+			 432000		; Expire
+			  38400 )	; Negative Cache TTL
+;
+@	IN	NS	@@serverexternname@@.
+@	IN	MX	10    @@serverexternname@@.
+@@serverexternname@@.	IN	A	@@serverip@@
+

--- a/var/config-dynamic/04_bind9/db.extern.target
+++ b/var/config-dynamic/04_bind9/db.extern.target
@@ -1,0 +1,1 @@
+/etc/bind/db.extern

--- a/var/config-dynamic/04_bind9/named.conf.extern
+++ b/var/config-dynamic/04_bind9/named.conf.extern
@@ -1,0 +1,9 @@
+//
+// Configuration for resolving extern server name intern
+//
+zone "@@serverexternname@@" in {
+    type master;
+    file "/etc/bind/db.extern";
+};
+
+

--- a/var/config-dynamic/04_bind9/named.conf.extern.target
+++ b/var/config-dynamic/04_bind9/named.conf.extern.target
@@ -1,0 +1,1 @@
+/etc/bind/named.conf.extern

--- a/var/config-dynamic/04_bind9/postpatch
+++ b/var/config-dynamic/04_bind9/postpatch
@@ -2,13 +2,22 @@
 
 echo "### 04_bind9 postpatch"
 
+# named.conf.extern must exist
+if [ ! -e /etc/bind/named.conf.extern ]; then
+  echo "// " >/etc/bind/named.conf.extern
+  echo "// Empty file" >>/etc/bind/named.conf.extern
+  echo "// " >>/etc/bind/named.conf.extern
+fi
+
 # fix permissions
 chown root:bind /etc/bind
 chmod 775 /etc/bind
 chown root:bind /etc/bind/db.10
 chown root:bind /etc/bind/db.linuxmuster
+chown -f root:bind /etc/bind/db.extern
 chmod 664 /etc/bind/db.10
 chmod 664 /etc/bind/db.linuxmuster
+chmod -f 664 /etc/bind/db.extern
 
 # delete journaling files
 ls /etc/bind/*.jnl &> /dev/null && rm /etc/bind/*.jnl

--- a/var/config-dynamic/04_bind9/prepatch
+++ b/var/config-dynamic/04_bind9/prepatch
@@ -13,6 +13,28 @@ if [ "$1" = "--modify" ]; then
   mv $i $i.nopatch
  done
 
+ # do patching for extern name if it is used for the first time
+ if [[ -z "$serverexternname_old" && -n "$serverexternname" ]]; then
+
+  mv named.conf.extern.target.nopatch named.conf.extern.target
+  mv db.extern.target.nopatch db.extern.target
+
+ elif [ -z "$serverexternname" ]; then
+
+  [ -e /etc/bind/named.conf.extern ] && backup_file /etc/bind/named.conf.extern
+  rm -f /etc/bind/named.conf.extern
+  [ -e /etc/bind/db.extern ] && backup_file /etc/bind/db.extern
+  rm -f /etc/bind/db.extern
+
+ elif [[ "$serverexternname" != "$serverexternname_old" ]]; then
+
+  backup_file /etc/bind/named.conf.extern
+  sed -e "s/$serverexternname_old./$serverexternname./g" -i /etc/bind/named.conf.extern
+  backup_file /etc/bind/db.extern
+  sed -e "s/$serverexternname_old./$serverexternname./g" -i /etc/bind/db.extern
+
+ fi
+
  if [ "$servername" != "$servername_old" -o "$domainname" != "$domainname_old" ]; then
 
   backup_file /etc/bind/db.linuxmuster
@@ -39,6 +61,13 @@ if [ "$1" = "--modify" ]; then
 
   [ -e "$BACKUPDIR/etc/bind/db.linuxmuster-$DATETIME.gz" ] || backup_file /etc/bind/db.linuxmuster
   [ -e "$BACKUPDIR/etc/bind/db.10-$DATETIME.gz" ] || backup_file /etc/bind/db.10
+
+  if [ -e /etc/bind/db.extern ]; then
+
+   [ -e "$BACKUPDIR/etc/bind/db.extern-$DATETIME.gz" ] || backup_file /etc/bind/db.extern
+   sed -e "s/$serverip_old/$serverip/g" -i /etc/bind/db.extern
+  fi
+
   backup_file /etc/bind/named.conf.options
 
   n=$internsub; o=$internsub_old
@@ -69,4 +98,14 @@ if [ "$1" = "--modify" ]; then
  
  fi
 
+else
+
+ if [ -z "$serverexternname" ]; then
+
+  mv db.extern.target db.extern.target.nopatch
+  mv named.conf.extern.target named.conf.extern.target.nopatch
+  rm -f /etc/bind/db.extern
+  rm -f /etc/bind/named.conf.extern
+
+ fi
 fi

--- a/var/config-static/etc/bind/named.conf
+++ b/var/config-static/etc/bind/named.conf
@@ -50,6 +50,8 @@ zone "255.in-addr.arpa" {
 //  domains from whom undelegated responses are expected and trusted.
 // root-delegation-only exclude { "DE"; "MUSEUM"; };
 
+include "/etc/bind/named.conf.extern";
+
 include "/etc/bind/named.conf.local";
 
 include "/etc/bind/named.conf.linuxmuster";


### PR DESCRIPTION
Moodle benötigt an vielen Stellen (Referenzen) absolute URLs. Diese müssen natürlich intern und extern aufgelöst werden. Falls aber der Server über einen Dyndns-Namen verfügt, ergibt sich ein Problem. Das lässt sich lösen, indem der Name-Server den externen Moodle-Namen auch intern auflöst und dann eben direkt zur internen Serveraddresse.
Falls diese Funktion nicht benötigt wird, kann serverexternname einfach leer gelassen werden.

Die Variable "serverexternname" habe ich hinzugefügt, um z.B. einen dyndns-Namen einzugeben oder diese leer zu lassen. Bei einem "--modify" wird der Name wie bei den anderen Variablen auch in Moodle geändert. Falls der externe Name leer ist, wird "servername" "domainname" verwendet.

Ich habe bind geändert, um den dyndns-Namen intern aufzulösen. Falls der Name vorhanden ist, wird er und nur er intern aufgelöst. Falls er nicht vorhanden (leer) ist, wird dieser Teil der Namensauflösung außer Kraft gesetzt und stört damit den Rest des Systems nicht.

Die Auflösung erfolgt durch einen zusätzlichen Namensraum db.extern, der durch linuxmuster-setup hinzugefügt / entfernt wird.

Ich bitte um Einarbeitung dieser Anpassung oder um Änderungswünsche. Mir ist kein besserer Weg eingefallen, falls jemand einen weiß, bin ich für Hinweise dankbar.

Ich habe diese Änderung bereits einmal eingereicht für den sicherlich veralteten master branch. Ich habe sie jetzt an den aktuellen devel branch angepasst.

Das Paket linuxmuster-moodle ist für Baden-Württemberger Schulen nicht interessant, da es BelWü gibt, für mich in Niedersachsen mit mehreren selbst betriebenen Moodle-Servern ist es aber wichtig, ein solches Paket zur Verfügung zu haben, damit ich meinen eigenen und die von mir betreuten Schulen definiert und geordnet aktualisieren kann.

Ich hoffe daher sehr, dass diese Änderung Zustimmung findet. Ich bin auch gern bereit, beim Testen und korrigieren der sich ergebenden Probleme zu helfen.

Mit freundlichen Grüßen
Frank Schütte
