### PR TITLE
Fix, um die Installation von linuxmuster.net auch auf br0, br1, etc. bri...

### DIFF
--- a/share/scripts/helperfunctions.sh
+++ b/share/scripts/helperfunctions.sh
@@ -406,7 +406,7 @@ discover_nics() {
 
  n=0
  # fetch all interfaces and their macs from /sys
- for i in /sys/class/net/bond* /sys/class/net/eth* /sys/class/net/wlan* /sys/class/net/intern /sys/class/net/extern /sys/class/net/dmz; do
+ for i in /sys/class/net/bond* /sys/class/net/eth* /sys/class/net/br* /sys/class/net/wlan* /sys/class/net/intern /sys/class/net/extern /sys/class/net/dmz; do
 
   [ -e $i/address ] || continue
 


### PR DESCRIPTION
...dged networks zu erstellen.

Nötig, wenn z.B. der server gleichzeitig der VM-Host sein soll.
