### PR TITLE
lade linux-hwe-generic und damit header und kernel der aktuellen Distrib...

### DIFF
--- a/share/tasks/server
+++ b/share/tasks/server
@@ -30,8 +30,7 @@ libnss-db
 libnss-ldap
 libpam-ldap
 libsasl2-modules
-linux-headers-server
-linux-image-server
+linux-hwe-generic
 linux-firmware
 linux-firmware-nonfree
 linuxmuster-linbo


### PR DESCRIPTION
...ution (trusty) und eben den von ubuntu unterstützten HWE stacks.
- verhindert die nervigen HWE-Meldungen -> fixed FS#355

Conflicts:
    share/tasks/server
...aufgelöst - jetzt auch FS#355 für devel-branch
