### PR TITLE
Extend lease time to avoid disconnections of shares (win2000 suffers fro...

### DIFF
--- a/var/config-dynamic/05_dhcp/dhcpd.conf.pxegrub
+++ b/var/config-dynamic/05_dhcp/dhcpd.conf.pxegrub
@@ -52,8 +52,15 @@ subnet @@internalnet@@ netmask @@dhcpmask@@ {
 }
 ### linuxmuster - end ### DON'T REMOVE THIS LINE ###
 
+group {
+# groessere lease time fuer feste ips
+default-lease-time 172800;
+max-lease-time 172800;
+
 # dynamically created stuff by import_workstations is included
 include "/etc/dhcp/dhcpd.conf.linuxmuster";
 
 # put your custom stuff in this included file
 include "/etc/dhcp/dhcpd.conf.custom";
+
+}

--- a/var/config-dynamic/05_dhcp/dhcpd.conf.pxelinux
+++ b/var/config-dynamic/05_dhcp/dhcpd.conf.pxelinux
@@ -66,8 +66,15 @@ subnet @@internalnet@@ netmask @@dhcpmask@@ {
 }
 ### linuxmuster - end ### DON'T REMOVE THIS LINE ###
 
+group {
+# groessere lease time fuer feste ips
+default-lease-time 172800;
+max-lease-time 172800;
+
 # dynamically created stuff by import_workstations is included
 include "/etc/dhcp/dhcpd.conf.linuxmuster";
 
 # put your custom stuff in this included file
 include "/etc/dhcp/dhcpd.conf.custom";
+
+}


### PR DESCRIPTION
...m this)

Hi, I do use this patch for quite some years and forgot about it. Lately I was reminded of it. Somehow dhcp uses 3600 from subnet, if no new group around the hosts is created.
At least win2000 suffers from share disconnections (leads to corrupt database in our library program Allegro).
