### PR TITLE
Fix 461 by calling custom.bat if it exists.

### DIFF
--- a/var/config-dynamic/17_admins/logon.bat
+++ b/var/config-dynamic/17_admins/logon.bat
@@ -49,4 +49,6 @@ REM *******************************************************
 REM *                 Sonstige Anpassungen                *
 REM *******************************************************
 if exist \\%SERVER%\netlogon\common.bat call \\%SERVER%\netlogon\common.bat
+
+if exist \\%SERVER%\netlogon\custom.bat call \\%SERVER%\netlogon\custom.bat
 rem pause


### PR DESCRIPTION
Please include this fix as soon as possible (before 6.1).