### PR TITLE
Optimized "is IP in subnet" calculations

### DIFF
--- a/debian/init
+++ b/debian/init
@@ -271,6 +271,10 @@ write_rulesfile() {
 -A IN-$IFACE ! -s $internalnet/$INTERNBITMASK -j ACCEPT
 EOF
 
+ unset global_subnets
+ declare -A global_subnets
+ prepare_subnet_lookup_tab "$ALLOWEDNETS"
+
  # add custom rules before
  [ -r "$CUSTOMRULESBEFORE" ] && cat "$CUSTOMRULESBEFORE" >> "$IPTRULES"
 
@@ -301,7 +305,7 @@ EOF
   else # write rules into allowed and blocked chains
    for i in $IPS; do
     # if ip matches an already allowed subnet only a reject rule for bocked ips is needed
-    if ([ -n "$suballowed" ] && ipsubmatch "$i" "$ALLOWEDNETS"); then
+    if ([ -n "$suballowed" ] && is_ip_in_subnets "$i"); then
      if [ "$TYPE" = "BLOCKED" ]; then
       # create reject rule for ips which are blocked
       if ! echo "$UNBLOCKED_IPS" | grep -qw "$i"; then

--- a/share/scripts/internet_on_off.sh
+++ b/share/scripts/internet_on_off.sh
@@ -126,10 +126,14 @@ if [ "$subnetting" = "true" ]; then
  # are there any subnets?
  if [ -n "$networks" ]; then
 
+  unset global_subnets
+  declare -A global_subnets
+  prepare_subnet_lookup_tab "$networks"
+
   # remove ips which match allowed subnets from allowed hosts
-  for i in $(awk -F\, '{ print $4}' $ALLOWEDHOSTS | sed -e 's|host ||g'); do
-   if ipsubmatch "$i" "$networks"; then
-    sed "/,host $i,/d" -i "$ALLOWEDHOSTS" || cancel "Cannot write to $ALLOWEDHOSTS 3!"
+  for ip in $(awk -F\, '{ print $4}' $ALLOWEDHOSTS | sed -e 's|host ||g'); do
+   if is_ip_in_subnets "$ip"; then
+    sed "/,host $ip,/d" -i "$ALLOWEDHOSTS" || cancel "Cannot write to $ALLOWEDHOSTS 3!"
    fi
   done
 


### PR DESCRIPTION
Rather then invoking ipcalc for every IP address to be checked,
use a global lookup table to decide, whether a IP is within
given subnet definitions.
This speeds up the internet_on_off.sh and intranet_on_off.sh
by factor 10. This was a problem on installations with a large
number of clients (500 and more) where enabling or disabling
internet/intranet took more then five minutes.

Signed-off: Nils Koenig <mail_linuxmuster@newk.it>